### PR TITLE
Update README to reflect pyvirtualcam 0.4 changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,16 +2,7 @@
 
 ![image](https://user-images.githubusercontent.com/2575698/84745620-d6a57b80-af82-11ea-8137-7e01dd188004.png)
 
-You'll need to install this also: https://obsproject.com/forum/resources/obs-virtualcam.949/
-
-if OBS is not installed, you can force the install of the driver with this:
-```
-regsvr32 /n /i:1 "obs-virtualcam\bin\32bit\obs-virtualsource.dll"
-regsvr32 /n /i:1 "obs-virtualcam\bin\64bit\obs-virtualsource.dll"
-```
-
-(compiled versions have been removed)
-
+You'll need to install OBS which provides the virtual camera: https://obsproject.com/
 
 If you want to run Chromicam from source, you will need Python3 and then you can do:
 
@@ -25,11 +16,6 @@ python3 chromicam.py https://www.youtube.com/watch?v=oHg5SJYRHA0 1280 720 30
 
 Stop OBS Virtual Cam before using with this tool if its already in use. 
 (Stop it in OBS if using it there, for example)
-
-If it crashes, deactive and reaactivate OBS Virtualcam (via its OBS device settings works)
-Also double check to make sure its not already in use by OBS or other app.
-
-This app will use the first OBS Virtualcam; others install are ignored.
 
 There will not be any video output unless the content is dynamic; it will update on scene changes.
 


### PR DESCRIPTION
pyvirtualcam 0.4 uses the new built-in virtual camera of OBS now (which also is much more stable), so there is no need anymore to install a separate plugin. There is only a single instance of the virtual camera, so I removed the relevant sentence talking about multiple cameras.